### PR TITLE
Fix Resizing

### DIFF
--- a/addons/IsoCube/IsoCube.gd
+++ b/addons/IsoCube/IsoCube.gd
@@ -185,6 +185,7 @@ func _ready():
 	connect("resized", self, "_update_rect_size")
 
 func _draw():
+	_update_rect_size();
 	# Top face
 	draw_polygon(_cached_top_point_array, _cached_top_pool_color, _top_uv, top_texture, null, antialiasing)
 	# Left face


### PR DESCRIPTION
Resize only works fine in the editor. In the runtime, the node is always on default even you change it's rect_size